### PR TITLE
feat: change default bg color

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,7 @@ const TURKISH_CHARACTERS = [
 const getInputResult = (input: string, word: string): CharacterGridWord => {
   const statuses: CharacterStatus[] = new Array(word.length)
     .fill(0)
-    .map(() => "default");
+    .map(() => "gray");
 
   const secondPassWordSet = [];
 

--- a/src/components/character-box/CharacterBox.tsx
+++ b/src/components/character-box/CharacterBox.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
 
-export type CharacterStatus = "default" | "green" | "yellow";
+export type CharacterStatus = "default" | "green" | "gray" | "yellow";
 
 export const CHARACTER_BOX_SIZE = 48;
 
 export const CHARACTER_STATUS_COLOR: Record<CharacterStatus, string> = {
-  default: "darkgray",
+  default: "gray",
+  gray: "darkgray",
   green: "#25952d",
   yellow: "#ddcc4f",
 };


### PR DESCRIPTION
When a new letter is input, the bg color would change to the same gray as submitted but not found letter. This meant when you fill a row with a guess, but not enter, it wasn't possible to differentiate it from a submitted word with no letters found.
With this PR, the background color will only change after the word is submitted.